### PR TITLE
Added support for building Llamafile from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,7 @@ script using the following command.
 ./bin/install-miniforge.sh
 ```
 
-### Llamafile (and friends!)
-
-TLDR: run the following command.
-
-```bash
-./bin/create-conda-env.sh && ./bin/install-llamafile.sh
-```
-
-#### 1. Creating the Conda environment
+### Creating the Conda environment
 
 After adding any necessary dependencies that should be downloaded via `conda` to the `environment.yml` file and any 
 dependencies that should be downloaded via `pip` to the `requirements.txt` file you create the Conda environment in a 
@@ -55,37 +47,46 @@ conda activate ./env
 Note that the `./env` directory is *not* under version control as it can always be re-created as 
 necessary.
 
-#### 2. Installing Llamafile (and friends!) 
+#### Support for NVIDIA GPU acceleration
 
-After creating the Conda environment you can install Llamafile (and Whisperfile and Sdfile) by running the following
-shell script.
+If you have an NVIDIA GPU, the in order to support GPU acceleration you need to install `cuda-toolkit` from the 
+`nvidia` Conda channel. This change is made in the `environment-nvidia-gpu.yml` file. Create the Conda environment 
+in a sub-directory `./env`of your project directory by running the following shell script.
 
 ```bash
-./bin/install-llamafile.sh
+./bin/create-conda-env.sh environment-nvidia-gpu.yml
 ```
 
-This script does the following.
+### Installing Llamafile (and friends!) 
 
-1. Downloads a [recent version](https://github.com/Mozilla-Ocho/llamafile/releases) of Llamafile.
-2. Installs Llamafile binary into the `bin/` directory of the Conda environment.
+After creating the Conda environment you can install Llamafile (and Whisperfile and Sdfile) by running the following
+command.
+
+```bash
+conda run --prefix ./env --live-stream ./bin/install-llamafile.sh
+```
+
+This command does the following.
+
+1. Properly configures the Conda environment.
+2. Downloads a [recent version](https://github.com/Mozilla-Ocho/llamafile/releases) of Llamafile.
+3. Installs Llamafile binary into the `bin/` directory of the Conda environment.
 
 By default, this script downloads a recent version of Llamafile. You can install a specific release by passing the 
 version number as a command line argument to the script as follows.
 
 ```bash
-./bin/install-llamafile.sh 0.8.13
+conda run --prefix ./env --live-stream ./bin/install-llamafile.sh 0.8.13
 ```
 
-### Llamafile (and friends!) with NVIDIA GPU acceleration
+### Building Llamafile (and friends!) from source (optional)
 
-TLDR: run the following command.
+After creating the Conda environment you can build Llamafile (and Whisperfile, Sdfile, and Llamafiler) by running 
+the following command.
 
 ```bash
-./bin/create-conda-env.sh environment-nvidia-gpu.yml && ./bin/install-llamafile.sh
+conda run --prefix ./env --live-stream ./bin/build-llamafile.sh
 ```
-
-To support NVIDIA GPU acceleration you need to install `cuda-toolkit` from the `nvidia` Conda channel. This 
-change is made in the `environment-nvidia-gpu.yml` file.
 
 ## Funding Acknowledgment
 

--- a/bin/build-llamafile.sh
+++ b/bin/build-llamafile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# entire script fails if a single command fails
+set -e
+
+# clone the llamafile repository
+PROJECT_DIR="$PWD"
+SRC_DIR="$PROJECT_DIR"/src/llamafile
+if [ ! -d "$SRC_DIR" ]; then git clone https://github.com/mozilla-ocho/llamafile "$SRC_DIR"; fi
+
+# compile using make and install into the bin/ directory of the conda environment
+make --directory "$SRC_DIR" clean
+make --directory "$SRC_DIR" --jobs PREFIX="$PROJECT_DIR"/env
+make --directory "$SRC_DIR" install PREFIX="$PROJECT_DIR"/env
+
+# remove the llamafile source code
+rm -rf "$SRC_DIR"

--- a/environment-nvidia-gpu.yml
+++ b/environment-nvidia-gpu.yml
@@ -6,6 +6,7 @@ channels:
   - nodefaults
 
 dependencies:
+  - cuda-nvcc
   - cuda-toolkit
   - jupyterlab
   - jupyterlab-lsp

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - jupyterlab
   - jupyterlab-lsp
+  - make
   - numpy
   - openai
   - pip


### PR DESCRIPTION
Currently in order to access Llamafiler you need to build Llamafile and friends from source. The provided build scripts support this.